### PR TITLE
Add mouse axes pointer lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ This provides a user-friendly interface to adjust:
 - **Mouse Axes Mode**:
   - **use_mouse_axes**: Set to `true` to derive joystick axes from mouse movement when modifiers are not held
   - **mouse_axes_modifiers**: List of keys or mouse buttons that temporarily disable mouse axes while pressed
+  - **mouse_axes_pointer_lock**: Return the cursor to an anchor position each frame to hide movement (default: `true`)
+  - **mouse_axes_lock_center**: Keep the anchor fixed at its first position or let it drift with movement
+  - **mouse_axes_invert_y**: Invert the Y axis for mouse-derived joystick movement
 - **Sector Boundaries**: Angle ranges for each attack direction
 - **Key Mappings**: Keyboard keys for each action
 - **Visualization Settings**: Window size and appearance
@@ -289,6 +292,10 @@ Alternatively, you can manually edit the configuration file located at:
 ```
 ~/.chakram_controller/config.json
 ```
+
+### Mouse Axes Pointer Lock (Windows/X11)
+
+Enabling `mouse_axes_pointer_lock` hides mouse movement from other applications by returning the cursor to an anchor position using native Win32 or X11 APIs. The anchor is locked to its initial position when `mouse_axes_lock_center` is `true`, but it can float if set to `false`. Use `mouse_axes_invert_y` to flip the vertical axis if needed.
 
 ## Input System
 

--- a/config_example.json
+++ b/config_example.json
@@ -1,0 +1,7 @@
+{
+  "use_mouse_axes": true,
+  "mouse_axes_modifiers": ["alt", "mouse4"],
+  "mouse_axes_pointer_lock": true,
+  "mouse_axes_lock_center": true,
+  "mouse_axes_invert_y": false
+}

--- a/src/chakram_controller.py
+++ b/src/chakram_controller.py
@@ -17,7 +17,8 @@ from src.config import (
     TRANSITION_SMOOTHNESS, TRANSITION_MIN_FACTOR, TRANSITION_MAX_FACTOR,
     COMBAT_MODE_ENABLED, COMBAT_MODE_KEY, COMBAT_MODE_DEADZONE, COMBAT_MODE_TRANSITION_SMOOTHNESS,
     GAME_STATE_DETECTION_ENABLED, COMBAT_TIMEOUT,
-    USE_MOUSE_AXES, MOUSE_AXES_MODIFIERS
+    USE_MOUSE_AXES, MOUSE_AXES_MODIFIERS, MOUSE_AXES_POINTER_LOCK,
+    MOUSE_AXES_LOCK_CENTER, MOUSE_AXES_INVERT_Y
 )
 from src.movement_analyzer import MovementAnalyzer
 from src.game_state_detector import GameStateDetector
@@ -28,7 +29,17 @@ class ChakramController:
         """Initialize the controller."""
         self.joystick = None
         self.use_mouse_axes = USE_MOUSE_AXES
-        self.mouse_axes = MouseAxes(MOUSE_AXES_MODIFIERS) if self.use_mouse_axes else None
+        self.mouse_axes = (
+            MouseAxes(
+                MOUSE_AXES_MODIFIERS,
+                scale=ALT_MODE_CURSOR_OFFSET,
+                pointer_lock=MOUSE_AXES_POINTER_LOCK,
+                lock_center=MOUSE_AXES_LOCK_CENTER,
+                invert_y=MOUSE_AXES_INVERT_Y,
+            )
+            if self.use_mouse_axes
+            else None
+        )
         print(f"use_mouse_axes={self.use_mouse_axes}, modifiers={MOUSE_AXES_MODIFIERS}")
         self.current_sector = None
         self.current_state = None  # "neutral", "cancel", "attack"

--- a/src/config.py
+++ b/src/config.py
@@ -53,6 +53,9 @@ DEFAULT_ALT_MODE_CURSOR_OFFSET = 20  # Default cursor movement distance in pixel
 # Mouse axes settings
 DEFAULT_USE_MOUSE_AXES = False
 DEFAULT_MOUSE_AXES_MODIFIERS = []
+DEFAULT_MOUSE_AXES_POINTER_LOCK = True
+DEFAULT_MOUSE_AXES_LOCK_CENTER = True
+DEFAULT_MOUSE_AXES_INVERT_Y = False
 
 # Game state detection settings
 DEFAULT_GAME_STATE_DETECTION_ENABLED = True
@@ -125,6 +128,9 @@ def load_user_config():
                 "alt_mode_cursor_offset": user_config.get("alt_mode_cursor_offset", DEFAULT_ALT_MODE_CURSOR_OFFSET),
                 "use_mouse_axes": user_config.get("use_mouse_axes", DEFAULT_USE_MOUSE_AXES),
                 "mouse_axes_modifiers": user_config.get("mouse_axes_modifiers", DEFAULT_MOUSE_AXES_MODIFIERS),
+                "mouse_axes_pointer_lock": user_config.get("mouse_axes_pointer_lock", DEFAULT_MOUSE_AXES_POINTER_LOCK),
+                "mouse_axes_lock_center": user_config.get("mouse_axes_lock_center", DEFAULT_MOUSE_AXES_LOCK_CENTER),
+                "mouse_axes_invert_y": user_config.get("mouse_axes_invert_y", DEFAULT_MOUSE_AXES_INVERT_Y),
                 "sectors": user_config.get("sectors", DEFAULT_SECTORS),
                 "key_mappings": user_config.get("key_mappings", DEFAULT_KEY_MAPPINGS),
                 "visualization": user_config.get("visualization", DEFAULT_VISUALIZATION),
@@ -167,6 +173,11 @@ def load_user_config():
         "deadzone_speed_threshold": DEFAULT_DEADZONE_SPEED_THRESHOLD,
         "release_delay": DEFAULT_RELEASE_DELAY,
         "sector_change_cooldown": DEFAULT_SECTOR_CHANGE_COOLDOWN,
+        "use_mouse_axes": DEFAULT_USE_MOUSE_AXES,
+        "mouse_axes_modifiers": DEFAULT_MOUSE_AXES_MODIFIERS,
+        "mouse_axes_pointer_lock": DEFAULT_MOUSE_AXES_POINTER_LOCK,
+        "mouse_axes_lock_center": DEFAULT_MOUSE_AXES_LOCK_CENTER,
+        "mouse_axes_invert_y": DEFAULT_MOUSE_AXES_INVERT_Y,
         "sectors": DEFAULT_SECTORS,
         "key_mappings": DEFAULT_KEY_MAPPINGS,
         "visualization": DEFAULT_VISUALIZATION,
@@ -213,6 +224,9 @@ ALT_MODE_KEY = user_config.get("alt_mode_key", DEFAULT_ALT_MODE_KEY)
 ALT_MODE_CURSOR_OFFSET = user_config.get("alt_mode_cursor_offset", DEFAULT_ALT_MODE_CURSOR_OFFSET)
 USE_MOUSE_AXES = user_config.get("use_mouse_axes", DEFAULT_USE_MOUSE_AXES)
 MOUSE_AXES_MODIFIERS = user_config.get("mouse_axes_modifiers", DEFAULT_MOUSE_AXES_MODIFIERS)
+MOUSE_AXES_POINTER_LOCK = user_config.get("mouse_axes_pointer_lock", DEFAULT_MOUSE_AXES_POINTER_LOCK)
+MOUSE_AXES_LOCK_CENTER = user_config.get("mouse_axes_lock_center", DEFAULT_MOUSE_AXES_LOCK_CENTER)
+MOUSE_AXES_INVERT_Y = user_config.get("mouse_axes_invert_y", DEFAULT_MOUSE_AXES_INVERT_Y)
 SECTORS = user_config["sectors"]
 KEY_MAPPINGS = user_config["key_mappings"]
 VISUALIZATION = user_config["visualization"]

--- a/src/mouse_axes.py
+++ b/src/mouse_axes.py
@@ -1,3 +1,6 @@
+import sys
+import ctypes
+import ctypes.util
 import pygame
 from src.config import ALT_MODE_CURSOR_OFFSET
 
@@ -15,15 +18,80 @@ KEY_OVERRIDES = {
     "shift": [pygame.K_LSHIFT, pygame.K_RSHIFT],
 }
 
+# Determine platform
+_platform = "win" if sys.platform.startswith("win") else "x11"
+
+if _platform == "win":
+    user32 = ctypes.windll.user32
+
+    class _POINT(ctypes.Structure):
+        _fields_ = [("x", ctypes.c_long), ("y", ctypes.c_long)]
+
+    def _get_cursor_pos():
+        pt = _POINT()
+        if not user32.GetCursorPos(ctypes.byref(pt)):
+            return pygame.mouse.get_pos()
+        return pt.x, pt.y
+
+    def _set_cursor_pos(x, y):
+        user32.SetCursorPos(int(x), int(y))
+
+else:
+    _x11 = None
+    _lib_name = ctypes.util.find_library("X11")
+    if _lib_name:
+        try:
+            _x11 = ctypes.cdll.LoadLibrary(_lib_name)
+        except OSError:
+            _x11 = None
+    if _x11 is None:
+        print("Warning: X11 not available; pointer lock disabled")
+
+    def _get_cursor_pos():
+        if _x11 is None:
+            return pygame.mouse.get_pos()
+        dpy = _x11.XOpenDisplay(None)
+        if not dpy:
+            return pygame.mouse.get_pos()
+        root = _x11.XDefaultRootWindow(dpy)
+        root_x = ctypes.c_int()
+        root_y = ctypes.c_int()
+        win_x = ctypes.c_int()
+        win_y = ctypes.c_int()
+        mask = ctypes.c_uint()
+        child = ctypes.c_ulong()
+        root_ret = ctypes.c_ulong()
+        _x11.XQueryPointer(dpy, root, ctypes.byref(root_ret), ctypes.byref(child),
+                           ctypes.byref(root_x), ctypes.byref(root_y),
+                           ctypes.byref(win_x), ctypes.byref(win_y),
+                           ctypes.byref(mask))
+        _x11.XCloseDisplay(dpy)
+        return root_x.value, root_y.value
+
+    def _set_cursor_pos(x, y):
+        if _x11 is None:
+            return
+        dpy = _x11.XOpenDisplay(None)
+        if not dpy:
+            return
+        root = _x11.XDefaultRootWindow(dpy)
+        _x11.XWarpPointer(dpy, 0, root, 0, 0, 0, 0, int(x), int(y))
+        _x11.XFlush(dpy)
+        _x11.XCloseDisplay(dpy)
+
+
 class MouseAxes:
-    def __init__(self, modifiers, scale=ALT_MODE_CURSOR_OFFSET):
+    def __init__(self, modifiers, scale=ALT_MODE_CURSOR_OFFSET, pointer_lock=True, lock_center=True, invert_y=False):
         self.modifiers = modifiers
         self.scale = scale if scale else 1
-        self.last_pos = None
+        self.pointer_lock = pointer_lock
+        self.lock_center = lock_center
+        self.invert_y = invert_y
+        self.anchor = None
 
     def initialize(self):
         pygame.event.pump()
-        self.last_pos = pygame.mouse.get_pos()
+        self.anchor = _get_cursor_pos()
         print(f"Mouse axes active. Modifiers: {self.modifiers}")
 
     def _modifier_pressed(self):
@@ -45,16 +113,23 @@ class MouseAxes:
 
     def get_axes(self):
         pygame.event.pump()
-        pos = pygame.mouse.get_pos()
-        if self.last_pos is None:
-            self.last_pos = pos
+        cur = _get_cursor_pos()
+        if self.anchor is None:
+            self.anchor = cur
             return 0.0, 0.0
         if self._modifier_pressed():
-            self.last_pos = pos
+            self.anchor = cur
             return 0.0, 0.0
-        dx = pos[0] - self.last_pos[0]
-        dy = pos[1] - self.last_pos[1]
-        self.last_pos = pos
+        dx = cur[0] - self.anchor[0]
+        dy = cur[1] - self.anchor[1]
+        if self.pointer_lock:
+            if not self.lock_center:
+                self.anchor = (self.anchor[0] + dx, self.anchor[1] + dy)
+            _set_cursor_pos(*self.anchor)
+        else:
+            self.anchor = cur
+        if self.invert_y:
+            dy = -dy
         x = max(-1.0, min(1.0, dx / self.scale))
         y = max(-1.0, min(1.0, dy / self.scale))
         return x, y


### PR DESCRIPTION
## Summary
- add cross-platform pointer lock helpers for mouse axes using Win32/X11 APIs
- expose pointer lock, center locking, and Y inversion options in config
- document mouse axes pointer lock usage and provide example config

## Testing
- `python -m py_compile src/mouse_axes.py src/config.py src/chakram_controller.py`


------
https://chatgpt.com/codex/tasks/task_b_6895a4ced2ac83338d91b4c69ae8f684