### PR TITLE
feat: add attack-on-release scheme for mouse axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ Alternatively, you can manually edit the configuration file located at:
 
 Enabling `mouse_axes_pointer_lock` hides mouse movement from other applications by returning the cursor to an anchor position using native Win32 or X11 APIs. The anchor is locked to its initial position when `mouse_axes_lock_center` is `true`, but it can float if set to `false`. Use `mouse_axes_invert_y` to flip the vertical axis if needed.
 
+### Attack on Modifier Release
+
+To perform attacks when releasing a modifier:
+
+- Enable mouse axes mode: `use_mouse_axes = true`
+- Turn on release attacks: `attack_on_modifier_release = true`
+- Choose the aiming modifier (must be in `mouse_axes_modifiers`), e.g. `aim_modifier = "alt"`
+- Optional: hold a block while aiming with `block_while_held = true` and set `block_key` (default `"right_mouse"`)
+
+While the modifier is held, moving the mouse selects an attack direction; releasing it presses and releases the corresponding attack key. Set `mouse_axes_invert_y = true` if the vertical direction feels inverted.
+
 ## Input System
 
 The application uses a sophisticated input system with two implementations:

--- a/config_example.json
+++ b/config_example.json
@@ -3,5 +3,13 @@
   "mouse_axes_modifiers": ["alt", "mouse4"],
   "mouse_axes_pointer_lock": true,
   "mouse_axes_lock_center": true,
-  "mouse_axes_invert_y": false
+  "mouse_axes_invert_y": false,
+  "attack_on_modifier_release": true,
+  "aim_modifier": "alt",
+  "aim_requires_movement": true,
+  "aim_direction_memory_ms": 250,
+  "attack_press_duration_ms": 50,
+  "post_attack_cooldown_ms": 200,
+  "block_while_held": true,
+  "block_key": "right_mouse"
 }

--- a/src/chakram_controller.py
+++ b/src/chakram_controller.py
@@ -18,7 +18,10 @@ from src.config import (
     COMBAT_MODE_ENABLED, COMBAT_MODE_KEY, COMBAT_MODE_DEADZONE, COMBAT_MODE_TRANSITION_SMOOTHNESS,
     GAME_STATE_DETECTION_ENABLED, COMBAT_TIMEOUT,
     USE_MOUSE_AXES, MOUSE_AXES_MODIFIERS, MOUSE_AXES_POINTER_LOCK,
-    MOUSE_AXES_LOCK_CENTER, MOUSE_AXES_INVERT_Y
+    MOUSE_AXES_LOCK_CENTER, MOUSE_AXES_INVERT_Y,
+    ATTACK_ON_MODIFIER_RELEASE, AIM_MODIFIER, AIM_REQUIRES_MOVEMENT,
+    AIM_DIRECTION_MEMORY_MS, ATTACK_PRESS_DURATION_MS, POST_ATTACK_COOLDOWN_MS,
+    BLOCK_WHILE_HELD, BLOCK_KEY
 )
 from src.movement_analyzer import MovementAnalyzer
 from src.game_state_detector import GameStateDetector
@@ -36,6 +39,14 @@ class ChakramController:
                 pointer_lock=MOUSE_AXES_POINTER_LOCK,
                 lock_center=MOUSE_AXES_LOCK_CENTER,
                 invert_y=MOUSE_AXES_INVERT_Y,
+                attack_on_modifier_release=ATTACK_ON_MODIFIER_RELEASE,
+                aim_modifier=AIM_MODIFIER,
+                aim_requires_movement=AIM_REQUIRES_MOVEMENT,
+                aim_direction_memory_ms=AIM_DIRECTION_MEMORY_MS,
+                attack_press_duration_ms=ATTACK_PRESS_DURATION_MS,
+                post_attack_cooldown_ms=POST_ATTACK_COOLDOWN_MS,
+                block_while_held=BLOCK_WHILE_HELD,
+                block_key=BLOCK_KEY,
             )
             if self.use_mouse_axes
             else None

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,14 @@ DEFAULT_MOUSE_AXES_MODIFIERS = []
 DEFAULT_MOUSE_AXES_POINTER_LOCK = True
 DEFAULT_MOUSE_AXES_LOCK_CENTER = True
 DEFAULT_MOUSE_AXES_INVERT_Y = False
+DEFAULT_ATTACK_ON_MODIFIER_RELEASE = True
+DEFAULT_AIM_MODIFIER = "alt"
+DEFAULT_AIM_REQUIRES_MOVEMENT = True
+DEFAULT_AIM_DIRECTION_MEMORY_MS = 250
+DEFAULT_ATTACK_PRESS_DURATION_MS = 50
+DEFAULT_POST_ATTACK_COOLDOWN_MS = 200
+DEFAULT_BLOCK_WHILE_HELD = True
+DEFAULT_BLOCK_KEY = "right_mouse"
 
 # Game state detection settings
 DEFAULT_GAME_STATE_DETECTION_ENABLED = True
@@ -131,6 +139,14 @@ def load_user_config():
                 "mouse_axes_pointer_lock": user_config.get("mouse_axes_pointer_lock", DEFAULT_MOUSE_AXES_POINTER_LOCK),
                 "mouse_axes_lock_center": user_config.get("mouse_axes_lock_center", DEFAULT_MOUSE_AXES_LOCK_CENTER),
                 "mouse_axes_invert_y": user_config.get("mouse_axes_invert_y", DEFAULT_MOUSE_AXES_INVERT_Y),
+                "attack_on_modifier_release": user_config.get("attack_on_modifier_release", DEFAULT_ATTACK_ON_MODIFIER_RELEASE),
+                "aim_modifier": user_config.get("aim_modifier", DEFAULT_AIM_MODIFIER),
+                "aim_requires_movement": user_config.get("aim_requires_movement", DEFAULT_AIM_REQUIRES_MOVEMENT),
+                "aim_direction_memory_ms": user_config.get("aim_direction_memory_ms", DEFAULT_AIM_DIRECTION_MEMORY_MS),
+                "attack_press_duration_ms": user_config.get("attack_press_duration_ms", DEFAULT_ATTACK_PRESS_DURATION_MS),
+                "post_attack_cooldown_ms": user_config.get("post_attack_cooldown_ms", DEFAULT_POST_ATTACK_COOLDOWN_MS),
+                "block_while_held": user_config.get("block_while_held", DEFAULT_BLOCK_WHILE_HELD),
+                "block_key": user_config.get("block_key", DEFAULT_BLOCK_KEY),
                 "sectors": user_config.get("sectors", DEFAULT_SECTORS),
                 "key_mappings": user_config.get("key_mappings", DEFAULT_KEY_MAPPINGS),
                 "visualization": user_config.get("visualization", DEFAULT_VISUALIZATION),
@@ -178,6 +194,14 @@ def load_user_config():
         "mouse_axes_pointer_lock": DEFAULT_MOUSE_AXES_POINTER_LOCK,
         "mouse_axes_lock_center": DEFAULT_MOUSE_AXES_LOCK_CENTER,
         "mouse_axes_invert_y": DEFAULT_MOUSE_AXES_INVERT_Y,
+        "attack_on_modifier_release": DEFAULT_ATTACK_ON_MODIFIER_RELEASE,
+        "aim_modifier": DEFAULT_AIM_MODIFIER,
+        "aim_requires_movement": DEFAULT_AIM_REQUIRES_MOVEMENT,
+        "aim_direction_memory_ms": DEFAULT_AIM_DIRECTION_MEMORY_MS,
+        "attack_press_duration_ms": DEFAULT_ATTACK_PRESS_DURATION_MS,
+        "post_attack_cooldown_ms": DEFAULT_POST_ATTACK_COOLDOWN_MS,
+        "block_while_held": DEFAULT_BLOCK_WHILE_HELD,
+        "block_key": DEFAULT_BLOCK_KEY,
         "sectors": DEFAULT_SECTORS,
         "key_mappings": DEFAULT_KEY_MAPPINGS,
         "visualization": DEFAULT_VISUALIZATION,
@@ -227,6 +251,14 @@ MOUSE_AXES_MODIFIERS = user_config.get("mouse_axes_modifiers", DEFAULT_MOUSE_AXE
 MOUSE_AXES_POINTER_LOCK = user_config.get("mouse_axes_pointer_lock", DEFAULT_MOUSE_AXES_POINTER_LOCK)
 MOUSE_AXES_LOCK_CENTER = user_config.get("mouse_axes_lock_center", DEFAULT_MOUSE_AXES_LOCK_CENTER)
 MOUSE_AXES_INVERT_Y = user_config.get("mouse_axes_invert_y", DEFAULT_MOUSE_AXES_INVERT_Y)
+ATTACK_ON_MODIFIER_RELEASE = user_config.get("attack_on_modifier_release", DEFAULT_ATTACK_ON_MODIFIER_RELEASE)
+AIM_MODIFIER = user_config.get("aim_modifier", DEFAULT_AIM_MODIFIER)
+AIM_REQUIRES_MOVEMENT = user_config.get("aim_requires_movement", DEFAULT_AIM_REQUIRES_MOVEMENT)
+AIM_DIRECTION_MEMORY_MS = user_config.get("aim_direction_memory_ms", DEFAULT_AIM_DIRECTION_MEMORY_MS)
+ATTACK_PRESS_DURATION_MS = user_config.get("attack_press_duration_ms", DEFAULT_ATTACK_PRESS_DURATION_MS)
+POST_ATTACK_COOLDOWN_MS = user_config.get("post_attack_cooldown_ms", DEFAULT_POST_ATTACK_COOLDOWN_MS)
+BLOCK_WHILE_HELD = user_config.get("block_while_held", DEFAULT_BLOCK_WHILE_HELD)
+BLOCK_KEY = user_config.get("block_key", DEFAULT_BLOCK_KEY)
 SECTORS = user_config["sectors"]
 KEY_MAPPINGS = user_config["key_mappings"]
 VISUALIZATION = user_config["visualization"]

--- a/src/mouse_axes.py
+++ b/src/mouse_axes.py
@@ -1,8 +1,16 @@
 import sys
 import ctypes
 import ctypes.util
+import time
+import math
 import pygame
-from src.config import ALT_MODE_CURSOR_OFFSET
+from src.config import (
+    ALT_MODE_CURSOR_OFFSET,
+    SECTORS,
+    KEY_MAPPINGS,
+    DEADZONE,
+)
+from src.win_input import key_down, key_up, right_mouse_down, right_mouse_up
 
 MOUSE_BUTTONS = {
     "left_mouse": 0,
@@ -81,35 +89,107 @@ else:
 
 
 class MouseAxes:
-    def __init__(self, modifiers, scale=ALT_MODE_CURSOR_OFFSET, pointer_lock=True, lock_center=True, invert_y=False):
+    STATE_IDLE = 0
+    STATE_AIMING = 1
+    STATE_COOLDOWN = 2
+
+    def __init__(
+        self,
+        modifiers,
+        scale=ALT_MODE_CURSOR_OFFSET,
+        pointer_lock=True,
+        lock_center=True,
+        invert_y=False,
+        attack_on_modifier_release=False,
+        aim_modifier=None,
+        aim_requires_movement=True,
+        aim_direction_memory_ms=250,
+        attack_press_duration_ms=50,
+        post_attack_cooldown_ms=200,
+        block_while_held=False,
+        block_key=None,
+    ):
         self.modifiers = modifiers
         self.scale = scale if scale else 1
         self.pointer_lock = pointer_lock
         self.lock_center = lock_center
         self.invert_y = invert_y
+
+        # Attack on release settings
+        self.attack_on_modifier_release = attack_on_modifier_release
+        self.aim_modifier = aim_modifier
+        self.aim_requires_movement = aim_requires_movement
+        self.aim_direction_memory_ms = aim_direction_memory_ms
+        self.attack_press_duration_ms = attack_press_duration_ms
+        self.post_attack_cooldown_ms = post_attack_cooldown_ms
+        self.block_while_held = block_while_held
+        self.block_key = block_key
+
+        # Runtime state
         self.anchor = None
+        self.state = self.STATE_IDLE
+        self.last_sector = None
+        self.last_sector_ts = 0.0
+        self.cooldown_until_ts = 0.0
+        self.prev_mod_pressed = False
+        self.block_pressed = False
 
     def initialize(self):
         pygame.event.pump()
         self.anchor = _get_cursor_pos()
         print(f"Mouse axes active. Modifiers: {self.modifiers}")
 
-    def _modifier_pressed(self):
+    def _is_modifier_pressed(self, mod):
         keys = pygame.key.get_pressed()
         buttons = pygame.mouse.get_pressed(5)
-        for mod in self.modifiers:
-            if mod in MOUSE_BUTTONS and buttons[MOUSE_BUTTONS[mod]]:
+        if mod in MOUSE_BUTTONS and buttons[MOUSE_BUTTONS[mod]]:
+            return True
+        codes = KEY_OVERRIDES.get(mod)
+        if codes and any(keys[c] for c in codes):
+            return True
+        try:
+            code = pygame.key.key_code(mod)
+            if keys[code]:
                 return True
-            codes = KEY_OVERRIDES.get(mod)
-            if codes and any(keys[c] for c in codes):
-                return True
-            try:
-                code = pygame.key.key_code(mod)
-                if keys[code]:
-                    return True
-            except Exception:
-                pass
+        except Exception:
+            pass
         return False
+
+    def _determine_sector(self, x, y):
+        distance = math.sqrt(x * x + y * y)
+        if distance < DEADZONE:
+            return None
+        angle = math.degrees(math.atan2(y, x))
+        if angle < 0:
+            angle += 360
+        for name, rng in SECTORS.items():
+            start = rng["start"]
+            end = rng["end"]
+            if start > end:
+                if angle >= start or angle <= end:
+                    return name
+            else:
+                if start <= angle <= end:
+                    return name
+        return None
+
+    def _press_block(self):
+        if not self.block_key:
+            return
+        if self.block_key == "right_mouse":
+            right_mouse_down()
+        else:
+            key_down(self.block_key)
+        self.block_pressed = True
+
+    def _release_block(self):
+        if not self.block_key or not self.block_pressed:
+            return
+        if self.block_key == "right_mouse":
+            right_mouse_up()
+        else:
+            key_up(self.block_key)
+        self.block_pressed = False
 
     def get_axes(self):
         pygame.event.pump()
@@ -117,17 +197,98 @@ class MouseAxes:
         if self.anchor is None:
             self.anchor = cur
             return 0.0, 0.0
-        if self._modifier_pressed():
-            self.anchor = cur
-            return 0.0, 0.0
+
+        now_ms = time.perf_counter() * 1000
+        if self.state == self.STATE_COOLDOWN and now_ms >= self.cooldown_until_ts:
+            self.state = self.STATE_IDLE
+
+        mod_pressed = self._is_modifier_pressed(self.aim_modifier) if self.aim_modifier else False
+
         dx = cur[0] - self.anchor[0]
         dy = cur[1] - self.anchor[1]
+
+        other_mod_pressed = any(
+            self._is_modifier_pressed(m)
+            for m in self.modifiers
+            if m != self.aim_modifier
+        )
+        if other_mod_pressed:
+            if self.pointer_lock:
+                if not self.lock_center:
+                    self.anchor = (self.anchor[0] + dx, self.anchor[1] + dy)
+                _set_cursor_pos(*self.anchor)
+            else:
+                self.anchor = cur
+            self.prev_mod_pressed = False
+            self.last_sector = None
+            self.state = self.STATE_IDLE
+            return 0.0, 0.0
+
+        # Handle modifier held
+        if mod_pressed and self.state != self.STATE_COOLDOWN:
+            if self.state == self.STATE_IDLE:
+                self.state = self.STATE_AIMING
+
+            if self.block_while_held and not self.block_pressed:
+                self._press_block()
+
+            if self.pointer_lock:
+                if not self.lock_center:
+                    self.anchor = (self.anchor[0] + dx, self.anchor[1] + dy)
+                _set_cursor_pos(*self.anchor)
+            else:
+                self.anchor = cur
+
+            if self.invert_y:
+                dy = -dy
+            x = max(-1.0, min(1.0, dx / self.scale))
+            y = max(-1.0, min(1.0, dy / self.scale))
+            sector = self._determine_sector(x, y)
+            if sector:
+                self.last_sector = sector
+                self.last_sector_ts = now_ms
+
+            self.prev_mod_pressed = True
+            return 0.0, 0.0
+
+        # Modifier just released
+        if self.prev_mod_pressed and not mod_pressed:
+            if self.block_while_held:
+                self._release_block()
+
+            if (
+                self.attack_on_modifier_release
+                and self.state == self.STATE_AIMING
+            ):
+                valid = True
+                if self.aim_requires_movement:
+                    if (
+                        not self.last_sector
+                        or now_ms - self.last_sector_ts > self.aim_direction_memory_ms
+                    ):
+                        valid = False
+                if valid and self.last_sector:
+                    attack_key = KEY_MAPPINGS.get(self.last_sector)
+                    if attack_key:
+                        key_down(attack_key)
+                        pygame.time.delay(self.attack_press_duration_ms)
+                        key_up(attack_key)
+                        self.cooldown_until_ts = now_ms + self.post_attack_cooldown_ms
+                        self.state = self.STATE_COOLDOWN
+
+            self.last_sector = None
+            self.last_sector_ts = 0.0
+            self.state = self.STATE_IDLE if self.state != self.STATE_COOLDOWN else self.STATE_COOLDOWN
+            self.prev_mod_pressed = False
+
+        # Standard axis processing
         if self.pointer_lock:
             if not self.lock_center:
                 self.anchor = (self.anchor[0] + dx, self.anchor[1] + dy)
             _set_cursor_pos(*self.anchor)
         else:
             self.anchor = cur
+
         if self.invert_y:
             dy = -dy
         x = max(-1.0, min(1.0, dx / self.scale))


### PR DESCRIPTION
## Summary
- add state machine to MouseAxes with hold-to-aim and release-to-strike logic
- wire new attack-on-release settings from configuration and controller
- document usage and update example config

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyKey'; AttributeError: module 'ctypes' has no attribute 'WinDLL')*


------
https://chatgpt.com/codex/tasks/task_b_6895af0073f08333926521e36d58a5f9