### PR TITLE
feat: log aim button events and lower default scale

### DIFF
--- a/docs/AIM_MODE.md
+++ b/docs/AIM_MODE.md
@@ -15,7 +15,7 @@ contains an `aim` section:
     "mode": "hold",
     "button": "mouse4",
     "auto_lmb": true,
-    "scale": 0.2
+    "scale": 0.1
   }
 }
 ```
@@ -23,7 +23,7 @@ contains an `aim` section:
 Only a subset of options is shown above. Missing keys are filled with defaults.
 
 By default, Aim Mode listens to the `mouse4` button (commonly the back side
-button on modern mice).
+button on modern mice) and applies a slowdown scale of `0.1`.
 
 ## CLI
 

--- a/src/aim/config.py
+++ b/src/aim/config.py
@@ -31,7 +31,7 @@ class AimConfig:
     mode: str = "hold"  # hold | toggle
     button: str = "mouse4"
     auto_lmb: bool = True
-    scale: float = 0.2
+    scale: float = 0.1
     scale_x: Optional[float] = None
     scale_y: Optional[float] = None
     min_step: int = 1
@@ -51,7 +51,7 @@ class AimConfig:
             mode=data.get("mode", "hold"),
             button=data.get("button", "mouse4"),
             auto_lmb=data.get("auto_lmb", True),
-            scale=data.get("scale", 0.2),
+            scale=data.get("scale", 0.1),
             scale_x=data.get("scale_x"),
             scale_y=data.get("scale_y"),
             min_step=data.get("min_step", 1),

--- a/src/aim/engine.py
+++ b/src/aim/engine.py
@@ -38,6 +38,7 @@ class AimEngine:
         Returns a list of synthetic LMB events (button, action).
         """
         if not self.enabled:
+            print("AimEngine: activation button event ignored (disabled)")
             return []
         out: List[Tuple[str, str]] = []
         if self.cfg.mode == "hold":
@@ -45,13 +46,18 @@ class AimEngine:
         else:  # toggle
             if pressed:
                 self.aiming = not self.aiming
+
+        print(f"AimEngine: button {'pressed' if pressed else 'released'}, aiming={self.aiming}")
+
         if self.cfg.auto_lmb:
             if self.aiming and not self._owns_lmb:
                 out.append(("LMB", "down"))
                 self._owns_lmb = True
+                print("AimEngine: auto LMB down")
             elif not self.aiming and self._owns_lmb:
                 out.append(("LMB", "up"))
                 self._owns_lmb = False
+                print("AimEngine: auto LMB up")
         return out
 
     # Movement scaling ------------------------------------------------

--- a/test_aim_engine.py
+++ b/test_aim_engine.py
@@ -38,7 +38,7 @@ def test_toggle_mode():
 
 def test_config_defaults():
     cfg = AimConfig.from_dict({})
-    assert cfg.scale == 0.2
+    assert cfg.scale == 0.1
     assert cfg.mode == "hold"
     assert cfg.enabled is True
     assert cfg.button == "mouse4"


### PR DESCRIPTION
## Summary
- log activation button presses and auto-LMB transitions in Aim Engine
- reduce default Aim Mode slowdown to 0.1 and refresh docs
- update tests for new default scale

## Testing
- `pytest test_aim_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a98ab530448333bc3977be17323300