### PR TITLE
Add mouse back button aliases for Aim Mode

### DIFF
--- a/docs/AIM_MODE.md
+++ b/docs/AIM_MODE.md
@@ -23,7 +23,8 @@ contains an `aim` section:
 Only a subset of options is shown above. Missing keys are filled with defaults.
 
 By default, Aim Mode listens to the `mouse4` button (commonly the back side
-button on modern mice) and applies a slowdown scale of `0.1`.
+button on modern mice) and applies a slowdown scale of `0.1`. Aliases such as
+`mouse_back` or simply `back` are also understood.
 
 ## CLI
 

--- a/src/aim/config.py
+++ b/src/aim/config.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+# Common aliases for mouse buttons. This allows users to refer to the
+# back button using different names and still have the configuration use
+# the canonical identifier expected by the rest of the code base.
+BUTTON_ALIASES = {
+    "mouse_back": "mouse4",
+    "back": "mouse4",
+    "xbutton1": "mouse4",
+    "mouse_x1": "mouse4",
+}
+
+
+def _normalize_button(name: str) -> str:
+    """Normalize button aliases to canonical names."""
+    key = name.lower()
+    return BUTTON_ALIASES.get(key, key)
+
 
 @dataclass
 class SmoothingConfig:
@@ -49,7 +65,7 @@ class AimConfig:
         return AimConfig(
             enabled=data.get("enabled", True),
             mode=data.get("mode", "hold"),
-            button=data.get("button", "mouse4"),
+            button=_normalize_button(data.get("button", "mouse4")),
             auto_lmb=data.get("auto_lmb", True),
             scale=data.get("scale", 0.1),
             scale_x=data.get("scale_x"),

--- a/test_aim_engine.py
+++ b/test_aim_engine.py
@@ -42,3 +42,10 @@ def test_config_defaults():
     assert cfg.mode == "hold"
     assert cfg.enabled is True
     assert cfg.button == "mouse4"
+
+
+def test_button_aliases():
+    cfg = AimConfig.from_dict({"button": "mouse_back"})
+    assert cfg.button == "mouse4"
+    cfg = AimConfig.from_dict({"button": "back"})
+    assert cfg.button == "mouse4"


### PR DESCRIPTION
## Summary
- Normalize activation button names for Aim Mode, supporting common back button aliases
- Document and test alias support for the mouse back button

## Testing
- `pytest test_aim_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_68a9912f293c8333a84a061d1b9b2294