### PR TITLE
Improve Aim Mode sensitivity reduction

### DIFF
--- a/docs/AIM_MODE.md
+++ b/docs/AIM_MODE.md
@@ -3,6 +3,10 @@
 Aim Mode slows down mouse movement and optionally auto-holds the left mouse button.
 It is intended for precise aiming while a chosen activation button is held or toggled.
 
+Internally the engine accumulates scaled mouse deltas to lower the effective
+pointer sensitivity. This avoids jitter from simple integer rounding and makes
+small movements feel smoother when Aim Mode is active.
+
 ## Configuration
 
 The global configuration file lives at `~/.chakram_controller/config.json` and

--- a/test_aim_engine.py
+++ b/test_aim_engine.py
@@ -15,8 +15,9 @@ def test_scale_move_basic():
     engine = make_engine(scale=0.5)
     engine.on_button(True)
     assert engine.scale_move(10, -10) == (5, -5)
-    # min_step ensures small movements survive
-    assert engine.scale_move(1, 0)[0] == 1
+    # small movements should accumulate when scaling is active
+    assert engine.scale_move(1, 0) == (0, 0)
+    assert engine.scale_move(1, 0) == (1, 0)
 
 
 def test_hold_auto_lmb():


### PR DESCRIPTION
## Summary
- accumulate scaled mouse deltas to reduce sensitivity smoothly
- update Aim Mode docs and tests for accumulation behavior

## Testing
- `pytest test_aim_engine.py -q`
- `pytest -q` *(fails: No module named 'interception'; no attribute WinDLL; missing pygame/keyboard/pyKey)*

------
https://chatgpt.com/codex/tasks/task_b_68a99c9ef5c8833385462f5ce5930cb9