### PR TITLE
Use OS pointer speed for Aim Mode sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,9 @@ This will launch an interactive test menu that allows you to test all aspects of
 
 ## Aim Mode
 
-Aim Mode provides a temporary precision mode by slowing mouse movement and
-optionally auto-holding the left mouse button. It is enabled by default and
-listens to the mouse back button (`mouse4`). Configuration lives in
+Aim Mode provides a temporary precision mode by lowering system mouse
+sensitivity and optionally auto-holding the left mouse button. It is enabled by
+default and listens to the mouse back button (`mouse4`). Configuration lives in
 `~/.chakram_controller/config.json` under the `aim` section and can be
 adjusted via command line:
 

--- a/docs/AIM_MODE.md
+++ b/docs/AIM_MODE.md
@@ -3,9 +3,9 @@
 Aim Mode slows down mouse movement and optionally auto-holds the left mouse button.
 It is intended for precise aiming while a chosen activation button is held or toggled.
 
-Internally the engine accumulates scaled mouse deltas to lower the effective
-pointer sensitivity. This avoids jitter from simple integer rounding and makes
-small movements feel smoother when Aim Mode is active.
+When active the engine temporarily reduces the operating system's mouse speed
+instead of scaling individual cursor deltas. This directly lowers pointer
+sensitivity for all movement, providing smoother low-speed control.
 
 ## Configuration
 
@@ -27,8 +27,9 @@ contains an `aim` section:
 Only a subset of options is shown above. Missing keys are filled with defaults.
 
 By default, Aim Mode listens to the `mouse4` button (commonly the back side
-button on modern mice) and applies a slowdown scale of `0.1`. Aliases such as
-`mouse_back` or simply `back` are also understood.
+button on modern mice) and applies a slowdown scale of `0.1` to the system
+pointer speed. Aliases such as `mouse_back` or simply `back` are also
+understood.
 
 ## CLI
 
@@ -39,7 +40,7 @@ python run.py --aim-status        # print current configuration
 python run.py --aim enable        # enable Aim Mode
 python run.py --aim disable       # disable Aim Mode
 python run.py --aim-set scale=0.5 # set new parameters
-python run.py --aim-test          # interactive scaling test
+python run.py --aim-test          # interactive speed test
 ```
 
 ## Warning

--- a/src/aim/system.py
+++ b/src/aim/system.py
@@ -1,0 +1,24 @@
+import sys
+if sys.platform == "win32":
+    import ctypes
+    SPI_GETMOUSESPEED = 0x0070
+    SPI_SETMOUSESPEED = 0x0071
+    SPIF_SENDCHANGE = 0x02
+
+    def get_mouse_speed() -> int:
+        speed = ctypes.c_int()
+        ctypes.windll.user32.SystemParametersInfoW(
+            SPI_GETMOUSESPEED, 0, ctypes.byref(speed), 0
+        )
+        return speed.value
+
+    def set_mouse_speed(speed: int) -> None:
+        ctypes.windll.user32.SystemParametersInfoW(
+            SPI_SETMOUSESPEED, 0, speed, SPIF_SENDCHANGE
+        )
+else:
+    def get_mouse_speed() -> int:
+        return 10
+
+    def set_mouse_speed(speed: int) -> None:
+        pass

--- a/test_aim_engine.py
+++ b/test_aim_engine.py
@@ -11,13 +11,27 @@ def make_engine(**kwargs) -> AimEngine:
     return AimEngine(cfg)
 
 
-def test_scale_move_basic():
+def test_scale_move_identity():
     engine = make_engine(scale=0.5)
     engine.on_button(True)
-    assert engine.scale_move(10, -10) == (5, -5)
-    # small movements should accumulate when scaling is active
-    assert engine.scale_move(1, 0) == (0, 0)
-    assert engine.scale_move(1, 0) == (1, 0)
+    assert engine.scale_move(10, -10) == (10, -10)
+
+
+def test_mouse_speed_adjustment(monkeypatch):
+    orig_speed = 10
+    speeds = []
+    monkeypatch.setattr("src.aim.engine.get_mouse_speed", lambda: orig_speed)
+
+    def fake_set(speed):
+        speeds.append(speed)
+
+    monkeypatch.setattr("src.aim.engine.set_mouse_speed", fake_set)
+
+    engine = make_engine(scale=0.5)
+    engine.on_button(True)
+    assert speeds[-1] == 5
+    engine.on_button(False)
+    assert speeds[-1] == orig_speed
 
 
 def test_hold_auto_lmb():


### PR DESCRIPTION
## Summary
- replace cursor delta scaling with system mouse speed reduction in Aim Mode
- document pointer speed approach and update Aim Mode description
- test mouse speed adjustment logic

## Testing
- `pytest test_aim_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a99f727c2c8333899f3de1848f9c69